### PR TITLE
Allow getMessage to also pass objects to custom defaultMessageCreator.

### DIFF
--- a/src/createValidator.js
+++ b/src/createValidator.js
@@ -14,7 +14,8 @@ function getMessage(
       return defaultMessageCreator;
     }
 
-    if (typeof config.field === 'string') {
+    const fieldType = typeof config.field; 
+    if (fieldType === 'string' || fieldType === 'object') {
       return defaultMessageCreator(config.field);
     }
   }


### PR DESCRIPTION
So this is a small feature request to allow objects to be passed to `defaultMessageCreator` that would help our use case quite significantly. 
To keep a long story short we're internationalizing our validation messages with react-intl by reimplementing the validators we need and passing a custom `defaultMessageCreator` to `createValidator` that returns an object instead of a string.
However when trying to internationalize the `field` parameter passed to `defaultMessageCreator` we run into an issue where only strings are accepted but the internationalization API requires an object consisting of `id` and `defaultMessage`.

This PR fixes that by allowing `config.field` to be an object while hopefully maintaining backwards compatibility.

Let me know if there's anything blocking this from being merged.

Best regards, Simon.