### PR TITLE
Fix incorrect example detail related to `hasLengthLessThan`

### DIFF
--- a/docs/common-validators/hasLengthLessThan.md
+++ b/docs/common-validators/hasLengthLessThan.md
@@ -8,5 +8,5 @@ length.
 import { hasLengthLessThan } from 'revalidate';
 
 hasLengthLessThan(4)('My Field')('hello');
-// 'My Field cannot be longer than 4 characters'
+// 'My Field cannot be longer than 3 characters'
 ```


### PR DESCRIPTION
Max length in the given example is 3 and not 4.