### PR TITLE
Fix off-by-one bug in `hasLengthLessThan`

### DIFF
--- a/__tests__/validators/hasLengthGreaterThan.test.js
+++ b/__tests__/validators/hasLengthGreaterThan.test.js
@@ -3,39 +3,39 @@ import repeat from 'lodash/repeat';
 import unconfigured from '../../src/validators/hasLengthGreaterThan';
 
 const FIELD = 'Foo';
-const MIN = 2;
-const hasLengthGreaterThan = unconfigured(MIN)(FIELD);
-const expectedErrorMessage = `${FIELD} must be longer than ${MIN} characters`;
+const LIMIT = 2;
+const hasLengthGreaterThan = unconfigured(LIMIT)(FIELD);
+const expectedErrorMessage = `${FIELD} must be longer than ${LIMIT} characters`;
 
-it('allows lengths greater than min', () => {
-  expect(hasLengthGreaterThan(repeat('a', MIN + 1))).toBe(undefined);
+it('allows lengths greater than the given value', () => {
+  expect(hasLengthGreaterThan(repeat('a', LIMIT + 1))).toBe(undefined);
 });
 
-it('does not allow lengths equal to min', () => {
-  expect(hasLengthGreaterThan(repeat('a', MIN))).toBe(expectedErrorMessage);
+it('does not allow lengths equal to the given value', () => {
+  expect(hasLengthGreaterThan(repeat('a', LIMIT))).toBe(expectedErrorMessage);
 });
 
-it('does not allow lengths less than min', () => {
-  expect(hasLengthGreaterThan(repeat('a', MIN - 1))).toBe(expectedErrorMessage);
+it('does not allow lengths less than the given value', () => {
+  expect(hasLengthGreaterThan(repeat('a', LIMIT - 1))).toBe(expectedErrorMessage);
 });
 
 it('unconfigured is cloneable', () => {
-  const clonedUnconfigured = unconfigured.clone((field, min) => (
-    `${field} error ${min}`
+  const clonedUnconfigured = unconfigured.clone((field, limit) => (
+    `${field} error ${limit}`
   ));
 
-  const cloned = clonedUnconfigured(MIN)(FIELD);
-  const expected = `${FIELD} error ${MIN}`;
+  const cloned = clonedUnconfigured(LIMIT)(FIELD);
+  const expected = `${FIELD} error ${LIMIT}`;
 
-  expect(cloned(repeat('a', MIN))).toBe(expected);
+  expect(cloned(repeat('a', LIMIT))).toBe(expected);
 });
 
 it('configured is cloneable', () => {
-  const cloned = unconfigured(MIN).clone((field, min) => (
-    `${field} error ${min}`
+  const cloned = unconfigured(LIMIT).clone((field, limit) => (
+    `${field} error ${limit}`
   ))(FIELD);
 
-  const expected = `${FIELD} error ${MIN}`;
+  const expected = `${FIELD} error ${LIMIT}`;
 
-  expect(cloned(repeat('a', MIN))).toBe(expected);
+  expect(cloned(repeat('a', LIMIT))).toBe(expected);
 });

--- a/__tests__/validators/hasLengthLessThan.test.js
+++ b/__tests__/validators/hasLengthLessThan.test.js
@@ -3,20 +3,21 @@ import repeat from 'lodash/repeat';
 import unconfigured from '../../src/validators/hasLengthLessThan';
 
 const FIELD = 'Foo';
-const MAX = 3;
-const hasLengthLessThan = unconfigured(MAX)(FIELD);
+const LESS_THAN_LIMIT = 4;
+const MAX = LESS_THAN_LIMIT - 1;
+const hasLengthLessThan = unconfigured(LESS_THAN_LIMIT)(FIELD);
 const expectedErrorMessage = `${FIELD} cannot be longer than ${MAX} characters`;
 
-it('allows lengths less than max', () => {
-  expect(hasLengthLessThan(repeat('a', MAX - 1))).toBe(undefined);
+it('allows lengths less than given value', () => {
+  expect(hasLengthLessThan(repeat('a', MAX))).toBe(undefined);
 });
 
-it('does not allow lengths equal to max', () => {
-  expect(hasLengthLessThan(repeat('a', MAX))).toBe(expectedErrorMessage);
+it('does not allow lengths equal to the given value', () => {
+  expect(hasLengthLessThan(repeat('a', LESS_THAN_LIMIT))).toBe(expectedErrorMessage);
 });
 
-it('does not allow lengths greater than max', () => {
-  expect(hasLengthLessThan(repeat('a', MAX + 1))).toBe(expectedErrorMessage);
+it('does not allow lengths greater than the given value', () => {
+  expect(hasLengthLessThan(repeat('a', LESS_THAN_LIMIT + 1))).toBe(expectedErrorMessage);
 });
 
 it('unconfigured is cloneable', () => {
@@ -24,18 +25,18 @@ it('unconfigured is cloneable', () => {
     `${field} error ${max}`
   ));
 
-  const cloned = clonedUnconfigured(MAX)(FIELD);
-  const expected = `${FIELD} error ${MAX}`;
+  const cloned = clonedUnconfigured(LESS_THAN_LIMIT)(FIELD);
+  const expected = `${FIELD} error ${LESS_THAN_LIMIT}`;
 
-  expect(cloned(repeat('a', MAX))).toBe(expected);
+  expect(cloned(repeat('a', LESS_THAN_LIMIT))).toBe(expected);
 });
 
 it('configured is cloneable', () => {
-  const cloned = unconfigured(MAX).clone((field, max) => (
-    `${field} error ${max}`
+  const cloned = unconfigured(LESS_THAN_LIMIT).clone((field, limit) => (
+    `${field} error ${limit}`
   ))(FIELD);
 
-  const expected = `${FIELD} error ${MAX}`;
+  const expected = `${FIELD} error ${LESS_THAN_LIMIT}`;
 
-  expect(cloned(repeat('a', MAX))).toBe(expected);
+  expect(cloned(repeat('a', LESS_THAN_LIMIT))).toBe(expected);
 });

--- a/docs/common-validators/hasLengthLessThan.md
+++ b/docs/common-validators/hasLengthLessThan.md
@@ -8,5 +8,5 @@ length.
 import { hasLengthLessThan } from 'revalidate';
 
 hasLengthLessThan(4)('My Field')('hello');
-// 'My Field cannot be longer than 4 characters'
+// 'My Field cannot be longer than 3 characters'
 ```

--- a/src/validators/hasLengthLessThan.js
+++ b/src/validators/hasLengthLessThan.js
@@ -8,5 +8,5 @@ export default createValidatorFactory(
     }
   },
 
-  (field, max: number) => `${field} cannot be longer than ${max} characters`,
+  (field, max: number) => `${field} cannot be longer than ${max - 1} characters`,
 );


### PR DESCRIPTION
This PR supersedes #53 by not just fixing the documentation, but also the incorrect error message. Also checked out `hasLengthGreaterThan` as @jfairbank suggested. Couldn't see a problem there, but did small renaming to make the tests easier to read.

Feel free to leave any comments or improvement ideas. I might be pretty busy, but I'll try to make required changes if possible.