### PR TITLE
Add props as extra argument to validators.

### DIFF
--- a/src/createValidator.js
+++ b/src/createValidator.js
@@ -53,7 +53,7 @@ export default function createValidator(
     return createValidator(curriedDefinition, newDefaultMessageCreator, ...args);
   }
 
-  function validator(config, value, allValues) {
+  function validator(config, value, allValues, props) {
     const message = getMessage(config, finalMessageCreator, ...args);
     const valueValidator = curriedDefinition(message, ...args);
 
@@ -61,7 +61,7 @@ export default function createValidator(
       return markAsValueValidator(valueValidator);
     }
 
-    return valueValidator(value, allValues);
+    return valueValidator(value, allValues, props);
   }
 
   validator.clone = clone;

--- a/src/internal/createValidatorWithSingleError.js
+++ b/src/internal/createValidatorWithSingleError.js
@@ -5,15 +5,15 @@ export default function createValidatorWithSingleError(
   validators: Array<Validator>,
   sharedConfig: ComposeConfig,
 ): ConfiguredValidator {
-  return function composedValidator(value, allValues) {
+  return function composedValidator(value, allValues, props) {
     for (let i = 0, l = validators.length; i < l; i++) {
       const validator = validators[i];
       let errorMessage;
 
       if (isValueValidator(validator)) {
-        errorMessage = validator(value, allValues);
+        errorMessage = validator(value, allValues, props);
       } else {
-        errorMessage = validator(sharedConfig, value, allValues);
+        errorMessage = validator(sharedConfig, value, allValues, props);
       }
 
       if (errorMessage) {

--- a/src/internal/internalCombineValidators.js
+++ b/src/internal/internalCombineValidators.js
@@ -24,19 +24,19 @@ export default function internalCombineValidators(
     return serializeValues(values) || {};
   }
 
-  return function valuesValidator(values, allValues) {
+  return function valuesValidator(values, props) {
     const serializedValues = finalSerializeValues(values);
-    const serializedAllValues = finalSerializeValues(allValues);
+    const serializedProps = finalSerializeValues(props);
 
     const finalErrors = Object.keys(validators).reduce((errors, fieldName) => {
       const parsedField = parseFieldName(fieldName);
       const validator = validators[parsedField.fullName];
       const value = serializedValues[parsedField.baseName];
-      const finalAllValues = atRoot ? serializedValues : serializedAllValues;
+      const finalAllValues = atRoot ? serializedValues : serializedProps;
 
       const errorMessage = parsedField.isArray
-        ? (value || []).map(fieldValue => validator(fieldValue, finalAllValues))
-        : validator(value, finalAllValues);
+        ? (value || []).map(fieldValue => validator(fieldValue, finalAllValues, serializedProps))
+        : validator(value, finalAllValues, serializedProps);
 
       if (errorMessage) {
         errors[parsedField.baseName] = errorMessage;


### PR DESCRIPTION
This is a proposed WIP change to add `props` as a third argument to validators. It is a fix for https://github.com/jfairbank/revalidate/issues/17.

This change allows you to depend on the `props` that redux-form passes along to the [validate prop](https://redux-form.com/7.3.0/docs/api/reduxform.md/#-code-validate-values-object-props-object-gt-errors-object-code-optional-).

e.g.
```
return createValidator(
    message => (value, allValues, props) => {
      if (!allValues || value !== allValues[otherField] || props.forceFail) {
        return message;
      }
    },

    field => `${field} must match ${otherFieldLabel}`
  );
```

Still TODO:
1. Update `createValidatorWithMultipleErrors.js`.
2. Update tests.

Looking for feedback from the project maintainer before continuing work on this.